### PR TITLE
Set up testing

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,12 @@
+# Ignore file for npm (https://docs.npmjs.com/cli/using-npm/developers)
+
+/*
+
+## Allowlist
+!index.js
+!LICENSE
+!package.json
+!README.md
+
+!index.cjs
+!is-supported-regexp-flag.cjs

--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,25 @@
+# Configuration file for Just (https://just.systems/)
+
+[private]
+@default:
+	just --list
+
+test: test-cjs test-esm
+
+[private]
+test-cjs: test-cjs-linear test-cjs-normal
+[private]
+test-cjs-linear:
+	node --enable-experimental-regexp-engine test.cjs
+[private]
+test-cjs-normal:
+	node test.cjs
+
+[private]
+test-esm: test-esm-linear test-esm-normal
+[private]
+test-esm-linear:
+	node --enable-experimental-regexp-engine test.js
+[private]
+test-esm-normal:
+	node test.js

--- a/is-supported-regexp-flag.cjs
+++ b/is-supported-regexp-flag.cjs
@@ -10,9 +10,9 @@
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-// The above copyright comes from the npm package is-supported-regexp-flag@2.0.0
-// (<https://www.npmjs.com/package/is-supported-regexp-flag>), which only offers
-// an ESM version of the code. This file contains a CommonJS version of that.
+// The above copyright notice is from npm:is-supported-regexp-flag@2.0.0 (see
+// <https://www.npmjs.com/package/is-supported-regexp-flag>), which only has an
+// ESM version of the code. This file contains a CommonJS version of that.
 
 function isSupportedRegexpFlag(flag) {
   try {

--- a/test.cjs
+++ b/test.cjs
@@ -1,0 +1,72 @@
+{
+	const lRegExp = require("./index.cjs");
+
+	const duration = time(() => {
+		const regexp = new lRegExp("(a*)*$");
+		regexp.test("a".repeat(16) + "b");
+	});
+
+	if (linearTimeEngine() && duration > 1) {
+		throw new Error(`matched unexpectedly slow (${duration}ms) with experimental regexp engine`);
+	} else if (!linearTimeEngine() && duration < 1) {
+		throw new Error(`matched unexpectedly fast (${duration}ms) with default regexp engine`);
+	}
+}
+
+/* -------------------------------------------------------------------------- */
+
+{
+	/**
+	 * MIT License
+	 *
+	 * Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
+	 *
+	 * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+	 *
+	 * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+	 *
+	 * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+	 */
+
+	// The above copyright notice is from npm:is-supported-regexp-flag@2.0.0 (see
+	// <https://www.npmjs.com/package/is-supported-regexp-flag>), which only has
+	// an ESM version of the tests. Below is a CommonJS version of that.
+
+	const isSupportedRegexpFlag = require("./is-supported-regexp-flag.cjs");
+
+	if (isSupportedRegexpFlag("g") !== true) {
+		throw new Error("flag 'g' unexpectedly unsupported");
+	}
+
+	if (isSupportedRegexpFlag("u") !== true) {
+		throw new Error("flag 'u' unexpectedly unsupported");
+	}
+
+	if (isSupportedRegexpFlag("q") !== false) {
+		throw new Error("flag 'q' unexpectedly supported");
+	}
+}
+
+/* -------------------------------------------------------------------------- */
+
+function time(cb) {
+	const { performance } = require("node:perf_hooks");
+
+	const start = performance.now();
+	cb();
+	const end = performance.now();
+
+	const duration = end - start;
+	return duration;
+}
+
+function linearTimeEngine() {
+	try {
+		new RegExp("", "l");
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+module.exports = { time, linearTimeEngine };

--- a/test.js
+++ b/test.js
@@ -1,0 +1,14 @@
+import { time, linearTimeEngine } from "./test.cjs";
+
+import lRegExp from "./index.js";
+
+const duration = time(() => {
+	const regexp = new lRegExp("(a*)*$");
+	regexp.test("a".repeat(16)+"b");
+});
+
+if (linearTimeEngine() && duration > 1) {
+	throw new Error(`matched unexpectedly slow (${duration}ms) with experimental regexp engine`);
+} else if (!linearTimeEngine() && duration < 1) {
+	throw new Error(`matched unexpectedly fast (${duration}ms) with default regexp engine`);
+}


### PR DESCRIPTION
Relates to #8

Create a test suite for this package itself as well as vendored code.

The own tests ensures that the experimental linear-time engine is used when the `--enable-experimental-regexp-engine` option is used (and sanity checks the test when it is not used) - identical for ESM and CJS.

The vendored code test suite is simply a mechanistic conversion of https://github.com/sindresorhus/is-supported-regexp-flag/blob/719e931/test.js