### PR TITLE
Don't create new constructor when not using experimental engine

### DIFF
--- a/index.cjs
+++ b/index.cjs
@@ -1,15 +1,11 @@
 const isSupportedRegexpFlag = require("./is-supported-regexp-flag.cjs");
 
-const RegExp_ = globalThis.RegExp;
+let lRegExp = RegExp;
 
-let lRegExp;
 if (isSupportedRegexpFlag("l")) {
+	const RegExp_ = globalThis.RegExp;
 	lRegExp = function(pattern, flags="") {
 		return new RegExp_(pattern, `${flags}l`);
-	};
-} else {
-	lRegExp = function(pattern, flags) {
-		return new RegExp_(pattern, flags);
 	};
 }
 

--- a/index.js
+++ b/index.js
@@ -1,15 +1,11 @@
 import isSupportedRegexpFlag from "is-supported-regexp-flag";
 
-const RegExp_ = globalThis.RegExp;
+let lRegExp = RegExp;
 
-let lRegExp;
 if (isSupportedRegexpFlag("l")) {
+	const RegExp_ = globalThis.RegExp;
 	lRegExp = function(pattern, flags="") {
 		return new RegExp_(pattern, `${flags}l`);
-	};
-} else {
-	lRegExp = function(pattern, flags) {
-		return new RegExp_(pattern, flags);
 	};
 }
 


### PR DESCRIPTION
Refactor the main library to avoid creating a new constructor function for `lRegExp` if the experiment regular expression engine is not in use. Moreover, avoid capturing `RegExp` global unless necessary to define the "actual" `lRegExp` constructor.

Besides reducing the amount of code (and arguably simplifying), this also has a marginal performance benefit for users when the experiment regexp engine is not used, as demonstrated by the benchmarking results _(see commit message)_.

---

Relates to #8