### PR TITLE
Test against latest runtime dependency versions on recurring schedule

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,32 @@
+name: Nightly
+on:
+  schedule:
+    - cron: "0 3 * * 1"
+  workflow_dispatch: ~
+
+permissions: read-all
+
+jobs:
+  test:
+    name: Test against latest runtime dependency versions
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
+      - name: Install Node.js
+        uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
+        with:
+          cache: npm
+          node-version: 24.0.0
+      - name: Install Just
+        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3.0.0
+      - name: Install dependencies
+        run: npm clean-install
+      - name: Bump runtime dependencies to latest compatible
+        run: |
+          npm update --omit dev --omit optional --omit peer
+          npm ls --all --omit dev --omit optional --omit peer
+      - name: Run tests
+        run: just test

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Eric Cornelissen
+Copyright (c) 2025-2026 Eric Cornelissen
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
To be made aware of breakage with dependencies within the supported version ranges.

---

Closes #17