### PR TITLE
Remove unnecessary locally scoped binding of global `RegExp`

### DIFF
--- a/index.cjs
+++ b/index.cjs
@@ -3,9 +3,8 @@ const isSupportedRegexpFlag = require("./is-supported-regexp-flag.cjs");
 let lRegExp = RegExp;
 
 if (isSupportedRegexpFlag("l")) {
-	const RegExp_ = globalThis.RegExp;
 	lRegExp = function(pattern, flags="") {
-		return new RegExp_(pattern, `${flags}l`);
+		return new RegExp(pattern, `${flags}l`);
 	};
 }
 

--- a/index.js
+++ b/index.js
@@ -3,9 +3,8 @@ import isSupportedRegexpFlag from "is-supported-regexp-flag";
 let lRegExp = RegExp;
 
 if (isSupportedRegexpFlag("l")) {
-	const RegExp_ = globalThis.RegExp;
 	lRegExp = function(pattern, flags="") {
-		return new RegExp_(pattern, `${flags}l`);
+		return new RegExp(pattern, `${flags}l`);
 	};
 }
 


### PR DESCRIPTION
Relates to #12